### PR TITLE
Add support for RedHat family systems

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -9,6 +9,9 @@ galaxy_info:
     - name: Ubuntu
       versions:
         - All
+    - name: EL
+      versions:
+        - All
   categories:
     - development
 # List your role dependencies here, one per line. Only

--- a/tasks/Debian.yml
+++ b/tasks/Debian.yml
@@ -1,6 +1,6 @@
 ---
 
-- name: Installing packages
+- name: Installing packages on Debian
   apt: >
     pkg={{ item }}
     state=present

--- a/tasks/RedHat.yml
+++ b/tasks/RedHat.yml
@@ -1,0 +1,32 @@
+---
+
+- name: Installing packages on RedHat
+  yum: >
+    pkg={{ item }}
+    state=present
+  with_items:
+    - vim
+  tags:
+    - development
+    - vim
+    - install
+
+- name: Create vim configuration directory
+  when: ansible_os_family == 'RedHat'
+  file: state=directory dest=/etc/vim
+  tags:
+    - development
+    - vim
+    - config
+
+- name: Source vimrc.local
+  when: ansible_os_family == 'RedHat'
+  lineinfile:
+    state=present
+    dest=/etc/vimrc
+    insertafter=EOF
+    line='source /etc/vim/vimrc.local'
+  tags:
+    - development
+    - vim
+    - config

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,4 +1,9 @@
 ---
 
-- include: install.yml
+- include: Debian.yml
+  when: ansible_os_family == 'Debian'
+
+- include: RedHat.yml
+  when: ansible_os_family == 'RedHat'
+
 - include: config.yml


### PR DESCRIPTION
This changeset is (relatively speaking) complex but adds support for local
automated configuration on EL systems plus works around a few differences with
Debian/Ubuntu.
