### PR TITLE
Add Debian to platforms list

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -6,6 +6,9 @@ galaxy_info:
   min_ansible_version: 1.6
   license: MIT
   platforms:
+    - name: Debian
+      versions:
+        - All
     - name: Ubuntu
       versions:
         - All


### PR DESCRIPTION
This is purely cosmetic but since I'm using this on Debian (wheezy) I know it
works there.
